### PR TITLE
Add hotkey for stacking images

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -260,17 +260,20 @@ export default class MouseWheelZoomPlugin extends Plugin {
                 return sanitized.length === 0 || !/[A-Za-z0-9]/.test(sanitized);
             };
 
-            let index = lines.findIndex(line => line.includes(searchString) && isImageLine(line));
-            if (index === -1) {
-                return fileText;
+    private async getActivePaneWithImage(imageElement: Element): Promise<TFile> {
+        return new Promise((resolve, reject) => {
+            let found = false;
+            this.app.workspace.iterateAllLeaves(leaf => {
+                if (!found && leaf.view.containerEl.contains(imageElement) && leaf.view instanceof MarkdownView) {
+                    found = true;
+                    resolve(leaf.view.file);
+                }
+            });
+            if (!found) {
+                reject(new Error("No file belonging to the image found"));
             }
-
-            let start = index;
-            let end = index;
-
-            while (start > 0 && (isImageLine(lines[start - 1]) || isIgnorable(lines[start - 1]))) start--;
-            while (end < lines.length - 1 && (isImageLine(lines[end + 1]) || isIgnorable(lines[end + 1]))) end++;
-
+        });
+    }
             const images = [] as string[];
             for (let i = start; i <= end; i++) {
                 if (isImageLine(lines[i])) {

--- a/main.ts
+++ b/main.ts
@@ -244,6 +244,13 @@ export default class MouseWheelZoomPlugin extends Plugin {
                 return trimmed;
             };
 
+                const sanitized = normalizeLine(line);
+                return obsidianImagePattern.test(sanitized) || markdownImagePattern.test(sanitized);
+                const sanitized = normalizeLine(line);
+                return sanitized.length === 0 || !/[A-Za-z0-9]/.test(sanitized);
+                return trimmed;
+            };
+
             const isImageLine = (line: string) => {
                 const sanitized = normalizeLine(line);
                 return obsidianImagePattern.test(sanitized) || markdownImagePattern.test(sanitized);

--- a/main.ts
+++ b/main.ts
@@ -237,13 +237,20 @@ export default class MouseWheelZoomPlugin extends Plugin {
             const obsidianImagePattern = /^!\[\[[^\]]+\]\](\|\d+)?\s*$/;
             const markdownImagePattern = /^!\[[^\]]*]\([^\)]+\)\s*$/;
 
+            const normalizeLine = (line: string) => {
+                let trimmed = line.trim();
+                trimmed = trimmed.replace(/^([-*+]|\d+\.)\s+/, '');
+                trimmed = trimmed.replace(/^\[[ xX]\]\s+/, '');
+                return trimmed;
+            };
+
             const isImageLine = (line: string) => {
-                const trimmed = line.trim();
-                return obsidianImagePattern.test(trimmed) || markdownImagePattern.test(trimmed);
+                const sanitized = normalizeLine(line);
+                return obsidianImagePattern.test(sanitized) || markdownImagePattern.test(sanitized);
             };
             const isIgnorable = (line: string) => {
-                const trimmed = line.trim();
-                return trimmed.length === 0 || !/[A-Za-z0-9]/.test(trimmed);
+                const sanitized = normalizeLine(line);
+                return sanitized.length === 0 || !/[A-Za-z0-9]/.test(sanitized);
             };
 
             let index = lines.findIndex(line => line.includes(searchString) && isImageLine(line));


### PR DESCRIPTION
## Summary
- add a command to stack adjacent images under the cursor
- ignore whitespace-only lines when stacking
- remove Alt+scroll behaviour for image stacking

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ac970f868832d9db94edf872a9165