### PR TITLE
Ignore blank lines when stacking images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ## Image Stacker
 
 This plugin stacks consecutive images onto the same line.
-Use the provided hotkey while hovering over an image to combine adjacent images.
+Use the provided hotkeys while hovering over an image to combine or split adjacent images.
+Available commands:
+- **Stack images under cursor**: merge consecutive image lines onto a single line.
+- **Unstack images under cursor**: split images on a single line onto separate lines with the same indentation.
 ![plugin demo](https://raw.githubusercontent.com/nicojeske/mousewheel-image-zoom/master/Animation.gif)
 
 ## How to install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## Obsidian mousewheel image zoom
+## Image Stacker
 
-This plugin enables you to increase/decrease the size of an image by holding down a configurable key (defaults to 
-left alt), hovering over an image in preview mode and scrolling.
+This plugin stacks consecutive images onto the same line.
+Use the provided hotkey while hovering over an image to combine adjacent images.
 ![plugin demo](https://raw.githubusercontent.com/nicojeske/mousewheel-image-zoom/master/Animation.gif)
 
 ## How to install

--- a/main.ts
+++ b/main.ts
@@ -2,7 +2,7 @@ import {App, MarkdownView, Plugin, PluginSettingTab, Setting, TFile, WorkspaceWi
 import { Util } from  "./src/util";
  
 
-interface MouseWheelZoomSettings {
+interface ImageStackerSettings {
     initialSize: number;
     modifierKey: ModifierKey;
     stepSize: number;
@@ -18,7 +18,7 @@ enum ModifierKey {
     SHIFT_RIGHT = "ShiftRight"
 }
 
-const DEFAULT_SETTINGS: MouseWheelZoomSettings = {
+const DEFAULT_SETTINGS: ImageStackerSettings = {
     modifierKey: ModifierKey.ALT,
     stepSize: 25,
     initialSize: 500,
@@ -28,9 +28,10 @@ const DEFAULT_SETTINGS: MouseWheelZoomSettings = {
 const CtrlCanvasConflictWarning = "Warning: Using Ctrl as the modifier key conflicts with default canvas zooming behavior when 'Resize in canvas' is enabled. Consider using another modifier key or disabling 'Resize in canvas'.";
  
 
-export default class MouseWheelZoomPlugin extends Plugin {
-    settings: MouseWheelZoomSettings;
+export default class ImageStackerPlugin extends Plugin {
+    settings: ImageStackerSettings;
     isKeyHeldDown = false;
+    lastHoveredImage: Element | null = null;
 
     async onload() {
         await this.loadSettings();
@@ -39,15 +40,27 @@ export default class MouseWheelZoomPlugin extends Plugin {
         );
         this.registerEvents(window);
 
-        this.addSettingTab(new MouseWheelZoomSettingsTab(this.app, this));
+        this.addSettingTab(new ImageStackerSettingsTab(this.app, this));
 
-        console.log("Loaded: Mousewheel image zoom")
+        this.addCommand({
+            id: 'stack-images-under-cursor',
+            name: 'Stack images under cursor',
+            callback: () => {
+                if (this.lastHoveredImage) {
+                    this.handleStack(this.lastHoveredImage);
+                } else {
+                    new Notice('Hover over an image and try again');
+                }
+            }
+        });
+
+        console.log("Loaded: Image Stacker")
 
         this.checkExistingUserConflict();
     }
 
     checkExistingUserConflict() {
-        const noticeShownKey = 'mousewheel-zoom-ctrl-warning-shown'; // Key for localStorage flag
+        const noticeShownKey = 'image-stacker-ctrl-warning-shown'; // Key for localStorage flag
         const isCtrl = this.settings.modifierKey === ModifierKey.CTRL || this.settings.modifierKey === ModifierKey.CTRL_RIGHT;
 
 
@@ -56,7 +69,7 @@ export default class MouseWheelZoomPlugin extends Plugin {
                 const fragment = document.createDocumentFragment();
 
                 const titleEl = document.createElement('strong');
-                titleEl.textContent = "Mousewheel Image Zoom";
+                titleEl.textContent = "Image Stacker";
                 fragment.appendChild(titleEl);
 
                 fragment.appendChild(document.createElement('br'));
@@ -109,6 +122,13 @@ export default class MouseWheelZoomPlugin extends Plugin {
      */
     private registerEvents(currentWindow: Window) {
         const doc: Document = currentWindow.document;
+
+        this.registerDomEvent(doc, "mousemove", (evt) => {
+            const target = evt.target as Element;
+            if (target.nodeName === "IMG") {
+                this.lastHoveredImage = target;
+            }
+        });
         this.registerDomEvent(doc, "keydown", (evt) => {
             if (evt.code === this.settings.modifierKey.toString()) {
                 // When canvas mode is enabled we just ignore the keydown event if the canvas is active
@@ -159,8 +179,7 @@ export default class MouseWheelZoomPlugin extends Plugin {
                     // i think here can be implementation of zoom images in embded markdown files on canvas. 
                 }
                 else if (targetIsImage) {
-                    // Stack consecutive image lines instead of resizing
-                    this.handleStack(evt, eventTarget);
+                    this.lastHoveredImage = eventTarget;
                 }
             }
         });
@@ -206,12 +225,11 @@ export default class MouseWheelZoomPlugin extends Plugin {
 
 
     /**
-     * Handles zooming with the mousewheel on an image
-     * @param evt wheel event
+     * Stack consecutive image lines triggered by a hotkey
      * @param eventTarget targeted image element
      * @private
      */
-    private async handleStack(evt: WheelEvent, eventTarget: Element) {
+    private async handleStack(eventTarget: Element) {
         const imageUri = eventTarget.attributes.getNamedItem("src").textContent;
 
         const activeFile: TFile = await this.getActivePaneWithImage(eventTarget);
@@ -372,11 +390,11 @@ export default class MouseWheelZoomPlugin extends Plugin {
 
 }
 
-class MouseWheelZoomSettingsTab extends PluginSettingTab {
-    plugin: MouseWheelZoomPlugin;
+class ImageStackerSettingsTab extends PluginSettingTab {
+    plugin: ImageStackerPlugin;
     warningEl: HTMLDivElement;
 
-    constructor(app: App, plugin: MouseWheelZoomPlugin) {
+    constructor(app: App, plugin: ImageStackerPlugin) {
         super(app, plugin);
         this.plugin = plugin;
     }
@@ -404,7 +422,7 @@ class MouseWheelZoomSettingsTab extends PluginSettingTab {
 
         containerEl.empty();
 
-        containerEl.createEl('h2', {text: 'Settings for mousewheel zoom'});
+        containerEl.createEl('h2', {text: 'Settings for Image Stacker'});
 
         new Setting(containerEl)
             .setName('Trigger Key')
@@ -466,7 +484,7 @@ class MouseWheelZoomSettingsTab extends PluginSettingTab {
 					});
 			});
 
-        this.warningEl = containerEl.createDiv({ cls: 'mousewheel-zoom-warning' });
+        this.warningEl = containerEl.createDiv({ cls: 'image-stacker-warning' });
         this.warningEl.style.display = 'none';
         this.updateWarningMessage(this.plugin.settings.modifierKey, this.plugin.settings.resizeInCanvas);
     

--- a/main.ts
+++ b/main.ts
@@ -236,7 +236,9 @@ export default class MouseWheelZoomPlugin extends Plugin {
 
             const isImageLine = (line: string) => {
                 const trimmed = line.trim();
-                return obsidianImagePattern.test(trimmed) || markdownImagePattern.test(trimmed);
+                // remove leading list markers like "-" or "1." before checking
+                const withoutListPrefix = trimmed.replace(/^(?:[-*+]\s*|\d+\.\s*)/, "");
+                return obsidianImagePattern.test(withoutListPrefix) || markdownImagePattern.test(withoutListPrefix);
             };
 
             const isIgnorableLine = (line: string) => {

--- a/main.ts
+++ b/main.ts
@@ -286,13 +286,19 @@ export default class ImageStackerPlugin extends Plugin {
             while (start > 0 && (isImageLine(lines[start - 1]) || isIgnorableLine(lines[start - 1]))) start--;
             while (end < lines.length - 1 && (isImageLine(lines[end + 1]) || isIgnorableLine(lines[end + 1]))) end++;
 
+            const prefixMatch = lines[start].match(/^(\s*(?:[-*+]\s*|\d+\.\s*)?)/);
+            const prefix = prefixMatch ? prefixMatch[0] : "";
+
             const images = [] as string[];
             for (let i = start; i <= end; i++) {
                 const trimmed = lines[i].trim();
-                if (isImageLine(trimmed)) images.push(trimmed);
+                if (isImageLine(trimmed)) {
+                    const withoutPrefix = trimmed.replace(/^(?:[-*+]\s*|\d+\.\s*)/, "");
+                    images.push(withoutPrefix);
+                }
             }
 
-            lines.splice(start, end - start + 1, images.join(' '));
+            lines.splice(start, end - start + 1, prefix + images.join(' '));
             const modifiedBody = lines.join('\n');
 
             return frontmatter + modifiedBody;

--- a/main.ts
+++ b/main.ts
@@ -289,17 +289,21 @@ export default class ImageStackerPlugin extends Plugin {
             const prefixMatch = lines[start].match(/^(\s*(?:[-*+]\s*|\d+\.\s*)?)/);
             const prefix = prefixMatch ? prefixMatch[0] : "";
 
-            const images = [] as string[];
-            for (let i = start; i <= end; i++) {
-                const trimmed = lines[i].trim();
-                if (isImageLine(trimmed)) {
-                    const withoutPrefix = trimmed.replace(/^(?:[-*+]\s*|\d+\.\s*)/, "");
-                    images.push(withoutPrefix);
-                }
+           const images = [] as string[];
+           for (let i = start; i <= end; i++) {
+               const trimmed = lines[i].trim();
+               if (isImageLine(trimmed)) {
+                   const withoutPrefix = trimmed.replace(/^(?:[-*+]\s*|\d+\.\s*)/, "");
+                   images.push(withoutPrefix);
+               }
+           }
+
+            if (images.length <= 1) {
+                return fileText;
             }
 
-            lines.splice(start, end - start + 1, prefix + images.join(' '));
-            const modifiedBody = lines.join('\n');
+           lines.splice(start, end - start + 1, prefix + images.join(' '));
+           const modifiedBody = lines.join('\n');
 
             return frontmatter + modifiedBody;
         });

--- a/main.ts
+++ b/main.ts
@@ -239,6 +239,10 @@ export default class MouseWheelZoomPlugin extends Plugin {
                 return obsidianImagePattern.test(trimmed) || markdownImagePattern.test(trimmed);
             };
 
+            const isIgnorableLine = (line: string) => {
+                return /^[\s-]*$/.test(line);
+            }
+
             let index = lines.findIndex(line => line.includes(searchString) && isImageLine(line));
             if (index === -1) {
                 return fileText;
@@ -247,13 +251,13 @@ export default class MouseWheelZoomPlugin extends Plugin {
             let start = index;
             let end = index;
 
-            while (start > 0 && isImageLine(lines[start - 1])) start--;
-            while (end < lines.length - 1 && isImageLine(lines[end + 1])) end++;
+            while (start > 0 && (isImageLine(lines[start - 1]) || isIgnorableLine(lines[start - 1]))) start--;
+            while (end < lines.length - 1 && (isImageLine(lines[end + 1]) || isIgnorableLine(lines[end + 1]))) end++;
 
             const images = [] as string[];
             for (let i = start; i <= end; i++) {
                 const trimmed = lines[i].trim();
-                if (trimmed.length > 0) images.push(trimmed);
+                if (isImageLine(trimmed)) images.push(trimmed);
             }
 
             lines.splice(start, end - start + 1, images.join(' '));

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "mousewheel-image-zoom",
-  "name": "Mousewheel Image zoom",
+  "id": "image-stacker",
+  "name": "Image Stacker",
   "version": "1.0.24",
   "minAppVersion": "0.9.12",
-  "description": "This plugin enables you to increase/decrease the size of an image by scrolling",
+  "description": "Stack consecutive images on one line using a hotkey",
   "author": "Nico Jeske",
-  "authorUrl": "https://github.com/nicojeske/mousewheel-image-zoom",
+  "authorUrl": "https://github.com/nicojeske/image-stacker",
   "isDesktopOnly": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Image Stacker",
   "version": "1.0.24",
   "minAppVersion": "0.9.12",
-  "description": "Stack consecutive images on one line using a hotkey",
+  "description": "Stack or unstack consecutive images with hotkeys",
   "author": "Nico Jeske",
   "authorUrl": "https://github.com/nicojeske/image-stacker",
   "isDesktopOnly": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-stacker",
   "version": "1.0.24",
-  "description": "Stack consecutive images on one line using a hotkey",
+  "description": "Stack or unstack consecutive images with hotkeys",
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mousewheel-image-zoom",
+  "name": "image-stacker",
   "version": "1.0.24",
-  "description": "This plugin enables you to increase/decrease the size of an image by scrolling",
+  "description": "Stack consecutive images on one line using a hotkey",
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",


### PR DESCRIPTION
## Summary
- update stacking logic
- ignore blank or dash-only lines when collecting image lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad5a862c0832db2e40313425a6ccf